### PR TITLE
feat(SCD41): implement sensor driver with initialization options

### DIFF
--- a/driver_notes/SCD41.md
+++ b/driver_notes/SCD41.md
@@ -1,0 +1,4 @@
+# Main
+
+- the sensor is no supposed to be used for Co2 in the current design; the co2 calibration interface is missing.
+- single shot features are also not implemented

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,3 +1,3 @@
-pub mod slf3s;
 pub mod explorir_m_e_100;
 pub mod scd41;
+pub mod slf3s;

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,2 +1,3 @@
 pub mod slf3s;
 pub mod explorir_m_e_100;
+pub mod scd41;

--- a/src/drivers/scd41.rs
+++ b/src/drivers/scd41.rs
@@ -6,7 +6,9 @@ use embassy_time::{Duration, Timer};
 // I2C Address
 const SCD41_I2C_ADDRESS: u8 = 0x62;
 
-const POWERUP_TIME: u32 = 40; // millisec
+// CRC
+const CRC8_INIT: u8 = 0xFF;
+const CRC_POLYNOMIAL: u8 = 0x31;
 
 // Basic commands
 const CMD_START_PERIODIC_MEASUREMENT: [u8; 2] = [0x21, 0xB1];
@@ -51,9 +53,10 @@ const CMD_PERFORM_SELF_TEST: [u8; 2] = [0x36, 0x39];
 // const CMD_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x23, 0x4B];
 
 // Execution times (in milliseconds)
+const POWERUP_TIME: u64 = 30;
 const INITIAL_MEASURE_DELAY: u64 = 500;
 const STOP_MEASURE_DELAY: u64 = 500;
-const PERFORM_SELF_TEST_DELAY: u64 = 10_000;
+const EXECUTION_TIME_PERFORM_SELF_TEST: u64 = 10000;
 const EXECUTION_TIME_READ_MEASUREMENT: u64 = 1;
 const EXECUTION_TIME_SET_TEMPERATURE_OFFSET: u64 = 1;
 const EXECUTION_TIME_GET_TEMPERATURE_OFFSET: u64 = 1;
@@ -61,15 +64,15 @@ const EXECUTION_TIME_SET_SENSOR_ALTITUDE: u64 = 1;
 const EXECUTION_TIME_GET_SENSOR_ALTITUDE: u64 = 1;
 const EXECUTION_TIME_SET_AMBIENT_PRESSURE: u64 = 1;
 const EXECUTION_TIME_GET_AMBIENT_PRESSURE: u64 = 1;
+const EXECUTION_TIME_GET_DATA_READY_STATUS: u64 = 1;
+const DATA_READY_LOOP_DELAY: u64 = 3000;
+const EXECUTION_TIME_GET_SERIAL_NUMBER: u64 = 1;
 // const EXECUTION_TIME_PERFORM_FORCED_RECALIBRATION: u64 = 400;
 // const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u64 = 1;
 // const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u64 = 1;
 // const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: u64 = 1;
 // const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: u64 = 1;
-const EXECUTION_TIME_GET_DATA_READY_STATUS: u64 = 1;
 // const EXECUTION_TIME_PERSIST_SETTINGS: u64 = 800;
-const EXECUTION_TIME_GET_SERIAL_NUMBER: u64 = 1;
-// const EXECUTION_TIME_PERFORM_SELF_TEST: u64 = 10000;
 // const EXECUTION_TIME_PERFORM_FACTORY_RESET: u64 = 1200;
 // const EXECUTION_TIME_REINIT: u64 = 30;
 // const EXECUTION_TIME_GET_SENSOR_VARIANT: u64 = 1;
@@ -81,21 +84,34 @@ const EXECUTION_TIME_GET_SERIAL_NUMBER: u64 = 1;
 // const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u64 = 1;
 // const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u64 = 1;
 
-//TODO make sure you stop measurement before any init commands
+//attempts counts
+const DATA_READ_MAX_ATTEMPTS: u8 = 5;
+
+enum SCD41State {
+    Idle,
+    Measurement,
+}
+
 pub struct SCD41<'d> {
     i2c: I2c<'d, Async>,
     i2c_address: u8,
+    scd41_state: SCD41State,
 }
-
 impl<'d> SCD41<'d> {
+    //N.B DO NOT USE THE SCD41 WITHOUT CALLING INIT
+    //verified
     pub fn new(i2c: I2c<'d, Async>) -> Self {
         SCD41 {
             i2c,
             i2c_address: SCD41_I2C_ADDRESS,
+            scd41_state: SCD41State::Measurement, //datasheet says it is idle but it seems to be in measurement mode
         }
     }
 
+    //verified
     pub async fn init(&mut self) -> Result<(), &'static str> {
+        Timer::after_millis(POWERUP_TIME).await;
+
         if let Err(e) = self.stop_periodic_measurement().await {
             error!("Failed to stop periodic measurement: {}", e);
             return Err("Failed to stop periodic measurement");
@@ -121,29 +137,269 @@ impl<'d> SCD41<'d> {
             return Err("Failed to start periodic measurement");
         }
         info!("CMD_START_PERIODIC_MEASUREMENT successfully sent");
-
         // [TODO] Set offsets here!!
 
         Ok(())
     }
 
-    //command words are not followed by CRC!
-    pub fn crc8(&self, data: &[u8]) -> u8 {
-        let mut crc: u8 = 0xFF; // Initialization value (CRC8_INIT)
+    //verified
+    pub async fn start_periodic_measurement(&mut self) -> Result<(), &'static str> {
+        self.send_command(&CMD_START_PERIODIC_MEASUREMENT)
+            .await
+            .map_err(|_| "Failed to start measurement")?;
+        self.scd41_state = SCD41State::Measurement;
+        Timer::after_millis(INITIAL_MEASURE_DELAY.into()).await;
+        Ok(())
+    }
+
+    //verified
+    pub async fn read_measurement(&mut self) -> Result<(u16, f32, f32), &'static str> {
+        let mut buf = [0u8; 9];
+        let mut attempts = 0;
+
+        while attempts < DATA_READ_MAX_ATTEMPTS {
+            if let Ok(true) = self.get_data_ready_status().await {
+                info!("Data ready; reading sensor");
+                match self
+                    .read_sequence(
+                        &CMD_READ_MEASUREMENT,
+                        &mut buf,
+                        EXECUTION_TIME_READ_MEASUREMENT,
+                    )
+                    .await
+                {
+                    Ok(()) => {
+                        let co2 = u16::from_be_bytes([buf[0], buf[1]]);
+                        let temperature =
+                            -45.0 + 175.0 * (u16::from_be_bytes([buf[3], buf[4]]) as f32 / 65535.0);
+                        let humidity =
+                            100.0 * (u16::from_be_bytes([buf[6], buf[7]]) as f32 / 65535.0);
+                        return Ok((co2, temperature, humidity));
+                    }
+                    Err(e) => return Err(e),
+                }
+            } else {
+                if attempts < DATA_READ_MAX_ATTEMPTS - 1 {
+                    info!("Data not ready; retrying in {}ms", DATA_READY_LOOP_DELAY);
+                    Timer::after_millis(DATA_READY_LOOP_DELAY).await;
+                    attempts += 1;
+                } else {
+                    return Err("Data not ready after max attempts");
+                }
+            }
+        }
+
+        Err("Unexpected error in read_measurement")
+    }
+
+    //verified
+    pub async fn stop_periodic_measurement(&mut self) -> Result<(), &'static str> {
+        self.send_command(&CMD_STOP_PERIODIC_MEASUREMENT)
+            .await
+            .map_err(|_| "Failed to stop measurement")?;
+        self.scd41_state = SCD41State::Idle;
+        Timer::after_millis(STOP_MEASURE_DELAY.into()).await;
+        Ok(())
+    }
+
+    pub async fn get_temp_offset(&mut self) -> Result<f32, &'static str> {
+        self.ensure_idle().await?;
+        let mut buf = [0u8; 3];
+        match self
+            .read_sequence(
+                &CMD_GET_TEMPERATURE_OFFSET,
+                &mut buf,
+                EXECUTION_TIME_GET_TEMPERATURE_OFFSET,
+            )
+            .await
+        {
+            Ok(()) => {
+                let raw_offset = u16::from_be_bytes([buf[0], buf[1]]);
+                let temp_offset = raw_offset as f32 * 175.0 / 65535.0;
+                Ok(temp_offset)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub async fn get_sensor_altitude(&mut self) -> Result<u16, &'static str> {
+        self.ensure_idle().await?;
+        let mut buf = [0u8; 3];
+        match self
+            .read_sequence(
+                &CMD_GET_SENSOR_ALTITUDE,
+                &mut buf,
+                EXECUTION_TIME_GET_SENSOR_ALTITUDE,
+            )
+            .await
+        {
+            Ok(()) => {
+                info!("{:#x}", buf);
+                let altitude = u16::from_be_bytes([buf[0], buf[1]]);
+                Ok(altitude)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub async fn get_ambient_pressure(&mut self) -> Result<u32, &'static str> {
+        self.ensure_idle().await?;
+        let mut buf = [0u8; 3];
+        match self
+            .read_sequence(
+                &CMD_GET_AMBIENT_PRESSURE,
+                &mut buf,
+                EXECUTION_TIME_GET_AMBIENT_PRESSURE,
+            )
+            .await
+        {
+            Ok(()) => {
+                let raw_pressure = u16::from_be_bytes([buf[0], buf[1]]);
+                let pressure_pa = u32::from(raw_pressure) * 100;
+                Ok(pressure_pa)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub async fn set_temperature_offset(
+        &mut self,
+        current_temp: f32,
+        reference_temp: f32,
+    ) -> Result<(), &'static str> {
+        self.ensure_idle().await?;
+        let previous_offset = match self.get_temp_offset().await {
+            Ok(offset) => offset,
+            Err(e) => return Err(e),
+        };
+
+        //given eqn in the datasheet
+        let actual_offset = current_temp - reference_temp + previous_offset;
+
+        // Check if the calculated offset is within the recommended range, this is not a hard limit though
+        if actual_offset < 0.0 || actual_offset > 20.0 {
+            return Err("Calculated temperature offset must be between 0 °C and 20 °C");
+        }
+
+        // word[0] = Toffset[°C] * (2^16 - 1) / 175
+        let raw_offset = ((actual_offset * 65535.0) / 175.0) as u16;
+        let offset_bytes = raw_offset.to_be_bytes();
+
+        self.write_command(&CMD_SET_TEMPERATURE_OFFSET, &offset_bytes)
+            .await
+    }
+
+    //this value must be in meters
+    pub async fn set_sensor_altitude(&mut self, altitude: u16) -> Result<(), &'static str> {
+        self.ensure_idle().await?;
+        if altitude > 3000 {
+            return Err("Altitude must be between 0 and 3000 meters");
+        }
+
+        let altitude_bytes = altitude.to_be_bytes();
+
+        self.write_command(&CMD_SET_SENSOR_ALTITUDE, &altitude_bytes)
+            .await
+    }
+
+    //value in pascals
+    pub async fn set_ambient_pressure(&mut self, pressure: u32) -> Result<(), &'static str> {
+        if pressure < 70_000 || pressure > 120_000 {
+            return Err("Pressure must be between 70,000 and 120,000 Pa");
+        }
+
+        let pressure_raw = (pressure / 100) as u16; // Convert Pa to 100 Pa units
+        let pressure_bytes = pressure_raw.to_be_bytes();
+
+        self.write_command(&CMD_SET_AMBIENT_PRESSURE, &pressure_bytes)
+            .await
+    }
+
+    async fn perform_self_test(&mut self) -> Result<bool, &'static str> {
+        self.ensure_idle().await?;
+        let mut buf = [0u8; 3];
+
+        match self
+            .read_sequence(
+                &CMD_PERFORM_SELF_TEST,
+                &mut buf,
+                EXECUTION_TIME_PERFORM_SELF_TEST,
+            )
+            .await
+        {
+            Ok(()) => {
+                let result = u16::from_be_bytes([buf[0], buf[1]]);
+                if result == 0 {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    //verified
+    pub async fn get_data_ready_status(&mut self) -> Result<bool, &'static str> {
+        //the data gets ready roughly once every 3000 milis
+        let mut buf = [0u8; 3];
+
+        match self
+            .read_sequence(
+                &CMD_GET_DATA_READY_STATUS,
+                &mut buf,
+                EXECUTION_TIME_GET_DATA_READY_STATUS,
+            )
+            .await
+        {
+            Ok(()) => {
+                // info!("{:#x}", buf);
+                if ((buf[0] & 0x07) == 0) && (buf[1] == 0) {
+                    Ok(false)
+                } else {
+                    Ok(true)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    //verified
+    //the answer should be: [0x7d, 0x6b, 0xab, 0x7b, 0x7, 0x37, 0x3b, 0x12, 0x8]
+    pub async fn get_serial_number(&mut self) -> Result<[u8; 9], &'static str> {
+        self.ensure_idle().await?;
+        let mut buf = [0u8; 9]; // 3 words, each followed by CRC (3 * (2 + 1) = 9)
+
+        match self
+            .read_sequence(
+                &CMD_GET_SERIAL_NUMBER,
+                &mut buf,
+                EXECUTION_TIME_GET_SERIAL_NUMBER,
+            )
+            .await
+        {
+            Ok(()) => Ok(buf),
+            Err(e) => Err(e),
+        }
+    }
+
+    //verified
+    fn crc8(&self, data: &[u8]) -> u8 {
+        let mut crc: u8 = CRC8_INIT;
         for &byte in data {
             crc ^= byte;
             for _ in 0..8 {
                 if crc & 0x80 != 0 {
-                    crc = (crc << 1) ^ 0x31; // 0x31 is the polynomial (CRC8_POLYNOMIAL)
+                    crc = (crc << 1) ^ CRC_POLYNOMIAL;
                 } else {
                     crc <<= 1;
                 }
             }
         }
-        crc // No final XOR needed as it's 0x00
+        crc
     }
 
-    //verified, works
+    //verified
     async fn send_command(&mut self, address: &[u8]) -> Result<(), &'static str> {
         self.i2c
             .write(self.i2c_address, address)
@@ -169,7 +425,8 @@ impl<'d> SCD41<'d> {
             .map_err(|_| "Error writing command")
     }
 
-    pub async fn read_sequence(
+    //verified
+    async fn read_sequence(
         &mut self,
         address: &[u8],
         buf: &mut [u8],
@@ -188,6 +445,7 @@ impl<'d> SCD41<'d> {
             .map_err(|_| "Error reading sequence")?;
 
         let mut i = 0;
+
         while i < buf.len() {
             let remaining = buf.len() - i;
             if remaining >= 3 {
@@ -200,6 +458,7 @@ impl<'d> SCD41<'d> {
                 }
                 i += 3;
             } else {
+                error!("Buffer size % 3 != 0; ignore if intended");
                 break;
             }
         }
@@ -207,234 +466,10 @@ impl<'d> SCD41<'d> {
         Ok(())
     }
 
-    pub async fn perform_self_test(&mut self) -> Result<bool, &'static str> {
-        let mut buf = [0u8; 3];
-
-        match self
-            .read_sequence(&CMD_PERFORM_SELF_TEST, &mut buf, PERFORM_SELF_TEST_DELAY)
-            .await
-        {
-            Ok(()) => {
-                let result = u16::from_be_bytes([buf[0], buf[1]]);
-                if result == 0 {
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    //verified works
-    pub async fn start_periodic_measurement(&mut self) -> Result<(), &'static str> {
-        self.send_command(&CMD_START_PERIODIC_MEASUREMENT)
-            .await
-            .map_err(|_| "Failed to start measurement")?;
-        Timer::after_millis(INITIAL_MEASURE_DELAY.into()).await;
-        Ok(())
-    }
-
-    pub async fn get_data_ready_status(&mut self) -> Result<bool, &'static str> {
-        let mut buf = [0u8; 3];
-        match self
-            .read_sequence(
-                &CMD_GET_DATA_READY_STATUS,
-                &mut buf,
-                EXECUTION_TIME_GET_DATA_READY_STATUS,
-            )
-            .await
-        {
-            Ok(()) => {
-                info!("{:#x}", buf);
-                if ((buf[0] & 0x07) == 0) && (buf[1] == 0) {
-                    Ok(false)
-                } else {
-                    Ok(true)
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    //[TODO]: Debug this little bitch
-    pub async fn read_measurement(&mut self) -> Result<(u16, f32, f32), &'static str> {
-        let mut buf = [0u8; 9];
-        if let Ok(true) = self.get_data_ready_status().await {
-            info!("The data from the sensor is ready and can be read");
-            match self
-                .i2c
-                .write(self.i2c_address, &CMD_READ_MEASUREMENT)
-                .await
-            {
-                Ok(()) => {
-                    info!("written success")
-                }
-                Err(e) => {
-                    error!("can't write!")
-                }
-            };
-
-            Timer::after_millis(1).await;
-
-            match self.i2c.read(self.i2c_address, &mut buf).await {
-                Ok(()) => {
-                    let co2 = u16::from_be_bytes([buf[0], buf[1]]);
-                    let temperature =
-                        -45.0 + 175.0 * (u16::from_be_bytes([buf[3], buf[4]]) as f32 / 65535.0);
-                    let humidity = 100.0 * (u16::from_be_bytes([buf[6], buf[7]]) as f32 / 65535.0);
-
-                    Ok((co2, temperature, humidity))
-                }
-                Err(e) => Err("can't read"),
-            }
-            // match self.read_sequence(&CMD_READ_MEASUREMENT, &mut buf).await {
-            //     Ok(()) => {
-            //         let co2 = u16::from_be_bytes([buf[0], buf[1]]);
-            //         let temperature =
-            //             -45.0 + 175.0 * (u16::from_be_bytes([buf[3], buf[4]]) as f32 / 65535.0);
-            //         let humidity = 100.0 * (u16::from_be_bytes([buf[6], buf[7]]) as f32 / 65535.0);
-
-            //         Ok((co2, temperature, humidity))
-            //     }
-            //     Err(e) => Err(e),
-            // }
-        } else {
-            Err("Sensor not ready yet. Try again in a few seconds")
-        }
-    }
-
-    //verified, works
-    pub async fn stop_periodic_measurement(&mut self) -> Result<(), &'static str> {
-        self.send_command(&CMD_STOP_PERIODIC_MEASUREMENT)
-            .await
-            .map_err(|_| "Failed to stop measurement")?;
-        Timer::after_millis(STOP_MEASURE_DELAY.into()).await;
-        Ok(())
-    }
-
-    //[TODO] make sure all the get and set commands make sure that the i2c is not in the periodic mode otherwise they will fail with a NACK
-    pub async fn get_temp_offset(&mut self) -> Result<f32, &'static str> {
-        let mut buf = [0u8; 3];
-        match self
-            .read_sequence(
-                &CMD_GET_TEMPERATURE_OFFSET,
-                &mut buf,
-                EXECUTION_TIME_GET_TEMPERATURE_OFFSET,
-            )
-            .await
-        {
-            Ok(()) => {
-                let raw_offset = u16::from_be_bytes([buf[0], buf[1]]);
-                let temp_offset = raw_offset as f32 * 175.0 / 65535.0;
-                Ok(temp_offset)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub async fn get_sensor_altitude(&mut self) -> Result<u16, &'static str> {
-        let mut buf = [0u8; 3];
-        match self
-            .read_sequence(
-                &CMD_GET_SENSOR_ALTITUDE,
-                &mut buf,
-                EXECUTION_TIME_GET_SENSOR_ALTITUDE,
-            )
-            .await
-        {
-            Ok(()) => {
-                info!("{:#x}", buf);
-                let altitude = u16::from_be_bytes([buf[0], buf[1]]);
-                Ok(altitude)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub async fn get_ambient_pressure(&mut self) -> Result<u32, &'static str> {
-        let mut buf = [0u8; 3];
-        match self
-            .read_sequence(
-                &CMD_GET_AMBIENT_PRESSURE,
-                &mut buf,
-                EXECUTION_TIME_GET_AMBIENT_PRESSURE,
-            )
-            .await
-        {
-            Ok(()) => {
-                let raw_pressure = u16::from_be_bytes([buf[0], buf[1]]);
-                let pressure_pa = u32::from(raw_pressure) * 100;
-                Ok(pressure_pa)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub async fn set_temperature_offset(
-        &mut self,
-        current_temp: f32,
-        reference_temp: f32,
-    ) -> Result<(), &'static str> {
-        let previous_offset = match self.get_temp_offset().await {
-            Ok(offset) => offset,
-            Err(e) => return Err(e),
-        };
-
-        //given eqn in the datasheet
-        let actual_offset = current_temp - reference_temp + previous_offset;
-
-        // Check if the calculated offset is within the recommended range, this is not a hard limit though
-        if actual_offset < 0.0 || actual_offset > 20.0 {
-            return Err("Calculated temperature offset must be between 0 °C and 20 °C");
-        }
-
-        // word[0] = Toffset[°C] * (2^16 - 1) / 175
-        let raw_offset = ((actual_offset * 65535.0) / 175.0) as u16;
-        let offset_bytes = raw_offset.to_be_bytes();
-
-        self.write_command(&CMD_SET_TEMPERATURE_OFFSET, &offset_bytes)
-            .await
-    }
-
-    //this value must be in meters
-    pub async fn set_sensor_altitude(&mut self, altitude: u16) -> Result<(), &'static str> {
-        if altitude > 3000 {
-            return Err("Altitude must be between 0 and 3000 meters");
-        }
-
-        let altitude_bytes = altitude.to_be_bytes();
-
-        self.write_command(&CMD_SET_SENSOR_ALTITUDE, &altitude_bytes)
-            .await
-    }
-
-    pub async fn set_ambient_pressure(&mut self, pressure: u32) -> Result<(), &'static str> {
-        if pressure < 70_000 || pressure > 120_000 {
-            return Err("Pressure must be between 70,000 and 120,000 Pa");
-        }
-
-        let pressure_raw = (pressure / 100) as u16; // Convert Pa to 100 Pa units
-        let pressure_bytes = pressure_raw.to_be_bytes();
-
-        self.write_command(&CMD_SET_AMBIENT_PRESSURE, &pressure_bytes)
-            .await
-    }
-
-    //the answer should be: [0x7d, 0x6b, 0xab, 0x7b, 0x7, 0x37, 0x3b, 0x12, 0x8]
-    pub async fn get_serial_number(&mut self) -> Result<[u8; 9], &'static str> {
-        let mut buf = [0u8; 9]; // 3 words, each followed by CRC (3 * (2 + 1) = 9)
-
-        match self
-            .read_sequence(
-                &CMD_GET_SERIAL_NUMBER,
-                &mut buf,
-                EXECUTION_TIME_GET_SERIAL_NUMBER,
-            )
-            .await
-        {
-            Ok(()) => Ok(buf),
-            Err(e) => Err(e),
+    async fn ensure_idle(&self) -> Result<(), &'static str> {
+        match self.scd41_state {
+            SCD41State::Idle => Ok(()),
+            SCD41State::Measurement => Err("Sensor in measurement mode. Stop measurement first."),
         }
     }
 

--- a/src/drivers/scd41.rs
+++ b/src/drivers/scd41.rs
@@ -1,3 +1,4 @@
+use defmt::{error, info};
 use embassy_stm32::i2c::I2c;
 use embassy_stm32::mode::Async;
 use embassy_time::Timer;
@@ -21,65 +22,69 @@ const CMD_SET_AMBIENT_PRESSURE: [u8; 2] = [0xE0, 0x00];
 const CMD_GET_AMBIENT_PRESSURE: [u8; 2] = [0xE0, 0x00];
 
 // Field calibration
-const CMD_PERFORM_FORCED_RECALIBRATION: [u8; 2] = [0x36, 0x2F];
-const CMD_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: [u8; 2] = [0x24, 0x16];
-const CMD_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: [u8; 2] = [0x23, 0x13];
-const CMD_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: [u8; 2] = [0x24, 0x3A];
-const CMD_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: [u8; 2] = [0x23, 0x3F];
+// const CMD_PERFORM_FORCED_RECALIBRATION: [u8; 2] = [0x36, 0x2F];
+// const CMD_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: [u8; 2] = [0x24, 0x16];
+// const CMD_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: [u8; 2] = [0x23, 0x13];
+// const CMD_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: [u8; 2] = [0x24, 0x3A];
+// const CMD_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: [u8; 2] = [0x23, 0x3F];
 
 // Low power periodic measurement mode
-const CMD_START_LOW_POWER_PERIODIC_MEASUREMENT: [u8; 2] = [0x21, 0xAC];
+// const CMD_START_LOW_POWER_PERIODIC_MEASUREMENT: [u8; 2] = [0x21, 0xAC];
 const CMD_GET_DATA_READY_STATUS: [u8; 2] = [0xE4, 0xB8];
 
 // Advanced features
-const CMD_PERSIST_SETTINGS: [u8; 2] = [0x36, 0x15];
-const CMD_GET_SERIAL_NUMBER: [u8; 2] = [0x36, 0x82];
+// const CMD_PERSIST_SETTINGS: [u8; 2] = [0x36, 0x15];
+// const CMD_GET_SERIAL_NUMBER: [u8; 2] = [0x36, 0x82];
 const CMD_PERFORM_SELF_TEST: [u8; 2] = [0x36, 0x39];
-const CMD_PERFORM_FACTORY_RESET: [u8; 2] = [0x36, 0x32];
-const CMD_REINIT: [u8; 2] = [0x36, 0x46];
-const CMD_GET_SENSOR_VARIANT: [u8; 2] = [0x20, 0x2F];
+// const CMD_PERFORM_FACTORY_RESET: [u8; 2] = [0x36, 0x32];
+// const CMD_REINIT: [u8; 2] = [0x36, 0x46];
+// const CMD_GET_SENSOR_VARIANT: [u8; 2] = [0x20, 0x2F];
 
 // Single shot measurement mode
-const CMD_MEASURE_SINGLE_SHOT: [u8; 2] = [0x21, 0x9D];
-const CMD_MEASURE_SINGLE_SHOT_RHT_ONLY: [u8; 2] = [0x21, 0x96];
-const CMD_POWER_DOWN: [u8; 2] = [0x36, 0xE0];
-const CMD_WAKE_UP: [u8; 2] = [0x36, 0xF6];
-const CMD_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: [u8; 2] = [0x24, 0x45];
-const CMD_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: [u8; 2] = [0x23, 0x40];
-const CMD_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x24, 0x4E];
-const CMD_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x23, 0x4B];
+// const CMD_MEASURE_SINGLE_SHOT: [u8; 2] = [0x21, 0x9D];
+// const CMD_MEASURE_SINGLE_SHOT_RHT_ONLY: [u8; 2] = [0x21, 0x96];
+// const CMD_POWER_DOWN: [u8; 2] = [0x36, 0xE0];
+// const CMD_WAKE_UP: [u8; 2] = [0x36, 0xF6];
+// const CMD_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: [u8; 2] = [0x24, 0x45];
+// const CMD_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: [u8; 2] = [0x23, 0x40];
+// const CMD_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x24, 0x4E];
+// const CMD_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x23, 0x4B];
 
 // Execution times (in milliseconds)
 const INITIAL_MEASURE_DELAY: u32 = 500;
-const EXECUTION_TIME_READ_MEASUREMENT: u32 = 1;
-const EXECUTION_TIME_STOP_PERIODIC_MEASUREMENT: u32 = 500;
-const EXECUTION_TIME_SET_TEMPERATURE_OFFSET: u32 = 1;
-const EXECUTION_TIME_GET_TEMPERATURE_OFFSET: u32 = 1;
-const EXECUTION_TIME_SET_SENSOR_ALTITUDE: u32 = 1;
-const EXECUTION_TIME_GET_SENSOR_ALTITUDE: u32 = 1;
-const EXECUTION_TIME_SET_AMBIENT_PRESSURE: u32 = 1;
-const EXECUTION_TIME_GET_AMBIENT_PRESSURE: u32 = 1;
-const EXECUTION_TIME_PERFORM_FORCED_RECALIBRATION: u32 = 400;
-const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
-const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
-const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
-const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
-const EXECUTION_TIME_GET_DATA_READY_STATUS: u32 = 1;
-const EXECUTION_TIME_PERSIST_SETTINGS: u32 = 800;
-const EXECUTION_TIME_GET_SERIAL_NUMBER: u32 = 1;
-const EXECUTION_TIME_PERFORM_SELF_TEST: u32 = 10000;
-const EXECUTION_TIME_PERFORM_FACTORY_RESET: u32 = 1200;
-const EXECUTION_TIME_REINIT: u32 = 30;
-const EXECUTION_TIME_GET_SENSOR_VARIANT: u32 = 1;
-const EXECUTION_TIME_MEASURE_SINGLE_SHOT: u32 = 5000;
-const EXECUTION_TIME_MEASURE_SINGLE_SHOT_RHT_ONLY: u32 = 50;
-const EXECUTION_TIME_POWER_DOWN: u32 = 1;
-const EXECUTION_TIME_WAKE_UP: u32 = 30;
-const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
-const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
-const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
-const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
+const STOP_MEASURE_DELAY: u32 = 500;
+const PERFORM_SELF_TEST_DELAY: u32 = 10_000;
 
+// const EXECUTION_TIME_READ_MEASUREMENT: u32 = 1;
+// const EXECUTION_TIME_STOP_PERIODIC_MEASUREMENT: u32 = 500;
+// const EXECUTION_TIME_SET_TEMPERATURE_OFFSET: u32 = 1;
+// const EXECUTION_TIME_GET_TEMPERATURE_OFFSET: u32 = 1;
+// const EXECUTION_TIME_SET_SENSOR_ALTITUDE: u32 = 1;
+// const EXECUTION_TIME_GET_SENSOR_ALTITUDE: u32 = 1;
+// const EXECUTION_TIME_SET_AMBIENT_PRESSURE: u32 = 1;
+// const EXECUTION_TIME_GET_AMBIENT_PRESSURE: u32 = 1;
+// const EXECUTION_TIME_PERFORM_FORCED_RECALIBRATION: u32 = 400;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
+// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
+// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
+// const EXECUTION_TIME_GET_DATA_READY_STATUS: u32 = 1;
+// const EXECUTION_TIME_PERSIST_SETTINGS: u32 = 800;
+// const EXECUTION_TIME_GET_SERIAL_NUMBER: u32 = 1;
+// const EXECUTION_TIME_PERFORM_SELF_TEST: u32 = 10000;
+// const EXECUTION_TIME_PERFORM_FACTORY_RESET: u32 = 1200;
+// const EXECUTION_TIME_REINIT: u32 = 30;
+// const EXECUTION_TIME_GET_SENSOR_VARIANT: u32 = 1;
+// const EXECUTION_TIME_MEASURE_SINGLE_SHOT: u32 = 5000;
+// const EXECUTION_TIME_MEASURE_SINGLE_SHOT_RHT_ONLY: u32 = 50;
+// const EXECUTION_TIME_POWER_DOWN: u32 = 1;
+// const EXECUTION_TIME_WAKE_UP: u32 = 30;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
+// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
+// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
+
+//TODO make sure you stop measurement before any init commands
 pub struct SCD41<'d> {
     i2c: I2c<'d, Async>,
     i2c_address: u8,
@@ -88,14 +93,31 @@ pub struct SCD41<'d> {
 impl<'d> SCD41<'d> {
     pub fn new(i2c: I2c<'d, Async>) -> Self {
         SCD41 {
-            i2c: i2c,
+            i2c,
             i2c_address: SCD41_I2C_ADDRESS,
         }
     }
 
-    //command words are not followed by CRC!!
-    //get this CRC checked once
-    fn crc8(&mut self, data: &[u8]) -> u8 {
+    pub async fn init(&mut self) -> Result<(), &'static str> {
+        match self.perform_self_test().await {
+            Ok(true) => {
+                info!("SCD41 self-test passed");
+                Ok(())
+            }
+            Ok(false) => {
+                error!("Sensor malfunction detected -- this could be either physical or temporary");
+                Err("Sensor malfunction detected")
+            }
+            Err(e) => {
+                error!("Error while trying to perform self test: {}", e);
+                Err(e)
+            }
+        }
+        // [TODO] Set offsets here!!
+    }
+
+    //command words are not followed by CRC!
+    pub fn crc8(&mut self, data: &[u8]) -> u8 {
         let mut crc: u8 = 0xFF; // Initialization value
         for &byte in data {
             crc ^= byte;
@@ -110,46 +132,6 @@ impl<'d> SCD41<'d> {
         crc // No final XOR needed as it's 0x00
     }
 
-    async fn write_command(&mut self, address: &[u8], data: &[u8]) -> Result<(), &'static str> {
-        const MAX_LENGTH: usize = 32;
-        let mut combined = [0u8; MAX_LENGTH];
-
-        if address.len() + data.len() + 1 > MAX_LENGTH {
-            return Err("Command too long");
-        }
-
-        let crc = self.crc8(data);
-
-        let mut index = 0;
-
-        for &byte in address {
-            combined[index] = byte;
-            index += 1;
-        }
-
-        for &byte in data {
-            combined[index] = byte;
-            index += 1;
-        }
-
-        combined[index] = crc;
-        index += 1;
-
-        self.i2c
-            .write(self.i2c_address, &combined[..index])
-            .await
-            .map_err(|_| "Error writing command")
-    }
-
-    //make sure SR here is same as ST according to the transaction contract
-    //i.e make sure it is write_read and not write and then read
-    async fn read_sequence(&mut self, address: &[u8], buf: &mut [u8]) -> Result<(), &'static str> {
-        self.i2c
-            .write_read(self.i2c_address, address, buf)
-            .await
-            .map_err(|_| "Error reading sequence")
-    }
-
     async fn send_command(&mut self, address: &[u8]) -> Result<(), &'static str> {
         self.i2c
             .write(self.i2c_address, address)
@@ -157,28 +139,65 @@ impl<'d> SCD41<'d> {
             .map_err(|_| "Error writing command")
     }
 
-    async fn send_command_and_fetch_result(
-        &mut self,
-        address: &[u8],
-        data: &[u8],
-        result: &mut [u8],
-    ) -> Result<(), &'static str> {
-        // Send command using the existing write_command function
-        self.write_command(address, data).await?;
+    async fn write_command(&mut self, address: &[u8], data: &[u8]) -> Result<(), &'static str> {
+        const MAX_LENGTH: usize = 5; // 2 (addr) + 2 (data) + 1(crc)
+        let mut combined = [0u8; MAX_LENGTH];
+
+        if address.len() + data.len() + 1 > MAX_LENGTH {
+            return Err("Command too long");
+        }
+
+        combined[..address.len()].copy_from_slice(address);
+        combined[address.len()..address.len() + data.len()].copy_from_slice(data);
+        combined[address.len() + data.len()] = self.crc8(data);
 
         self.i2c
-            .read(self.i2c_address, result)
+            .write(self.i2c_address, &combined)
             .await
-            .map_err(|_| "Error fetching result")?;
+            .map_err(|_| "Error writing command")
+    }
 
-        let result_data_len = result.len() - 1;
-        let received_crc = result[result_data_len];
-        let calculated_crc = self.crc8(&result[..result_data_len]);
-        if received_crc != calculated_crc {
-            return Err("CRC mismatch in result");
+    //make sure SR here is same as ST according to the transaction contract
+    //i.e make sure that both write_read and write and then read works here [TODO]
+    async fn read_sequence(&mut self, address: &[u8], buf: &mut [u8]) -> Result<(), &'static str> {
+        self.i2c
+            .write_read(self.i2c_address, address, buf)
+            .await
+            .map_err(|_| "Error reading sequence")?;
+
+        for chunk in buf.chunks(3) {
+            if chunk.len() == 3 {
+                let data = &chunk[0..2];
+                let received_crc = chunk[2];
+                let calculated_crc = self.crc8(data);
+                if calculated_crc != received_crc {
+                    return Err("CRC mismatch in read data");
+                }
+            } else {
+                return Err("The chunck was not divisible by 3");
+            }
         }
 
         Ok(())
+    }
+
+    pub async fn perform_self_test(&mut self) -> Result<bool, &'static str> {
+        let mut buf = [0u8; 3];
+
+        self.send_command(&CMD_PERFORM_SELF_TEST).await?;
+        Timer::after_millis(PERFORM_SELF_TEST_DELAY.into()).await;
+
+        match self.read_sequence(&CMD_PERFORM_SELF_TEST, &mut buf).await {
+            Ok(()) => {
+                let result = u16::from_be_bytes([buf[0], buf[1]]);
+                if result == 0 {
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Err(e) => Err(e),
+        }
     }
 
     pub async fn start_periodic_measurement(&mut self) -> Result<(), &'static str> {
@@ -196,17 +215,13 @@ impl<'d> SCD41<'d> {
             .await
         {
             Ok(()) => {
-                if self.crc8(&buf[0..=1]) == buf[2] {
-                    if (buf[0] & 0x07 == 0) && (buf[1] == 0) {
-                        Ok(false)
-                    } else {
-                        Ok(true)
-                    }
+                if ((buf[0] & 0x07) == 0) && (buf[1] == 0) {
+                    Ok(false)
                 } else {
-                    Err("the CRC has failed")
+                    Ok(true)
                 }
             }
-            Err(_) => Err("Failed to read data ready status: {}"),
+            Err(e) => Err(e),
         }
     }
 
@@ -215,21 +230,14 @@ impl<'d> SCD41<'d> {
         if let Ok(true) = self.get_data_ready_status().await {
             match self.read_sequence(&CMD_READ_MEASUREMENT, &mut buf).await {
                 Ok(()) => {
-                    if self.crc8(&buf[0..2]) != buf[2]
-                        || self.crc8(&buf[3..5]) != buf[5]
-                        || self.crc8(&buf[6..8]) != buf[8]
-                    {
-                        return Err("CRC mismatch in measurement data");
-                    }
-
                     let co2 = u16::from_be_bytes([buf[0], buf[1]]);
                     let temperature =
-                        -45.0 + 175.0 * u16::from_be_bytes([buf[3], buf[4]]) as f32 / 65535.0;
-                    let humidity = 100.0 * u16::from_be_bytes([buf[6], buf[7]]) as f32 / 65535.0;
+                        -45.0 + 175.0 * (u16::from_be_bytes([buf[3], buf[4]]) as f32 / 65535.0);
+                    let humidity = 100.0 * (u16::from_be_bytes([buf[6], buf[7]]) as f32 / 65535.0);
 
                     Ok((co2, temperature, humidity))
                 }
-                Err(_) => Err("Failed to read measurement data"),
+                Err(e) => Err(e),
             }
         } else {
             Err("Sensor not ready yet. Try again in a few seconds")
@@ -240,7 +248,7 @@ impl<'d> SCD41<'d> {
         self.send_command(&CMD_STOP_PERIODIC_MEASUREMENT)
             .await
             .map_err(|_| "Failed to stop measurement")?;
-        Timer::after_millis(INITIAL_MEASURE_DELAY.into()).await;
+        Timer::after_millis(STOP_MEASURE_DELAY.into()).await;
         Ok(())
     }
 
@@ -251,16 +259,11 @@ impl<'d> SCD41<'d> {
             .await
         {
             Ok(()) => {
-                if self.crc8(&buf[0..2]) != buf[2] {
-                    return Err("CRC mismatch in temperature offset data");
-                }
-
                 let raw_offset = u16::from_be_bytes([buf[0], buf[1]]);
                 let temp_offset = raw_offset as f32 * 175.0 / 65535.0;
-
                 Ok(temp_offset)
             }
-            Err(_) => Err("Error reading temperature offset"),
+            Err(e) => Err(e),
         }
     }
 
@@ -268,15 +271,10 @@ impl<'d> SCD41<'d> {
         let mut buf = [0u8; 3];
         match self.read_sequence(&CMD_GET_SENSOR_ALTITUDE, &mut buf).await {
             Ok(()) => {
-                if self.crc8(&buf[0..2]) != buf[2] {
-                    return Err("CRC mismatch in sensor altitude data");
-                }
-
                 let altitude = u16::from_be_bytes([buf[0], buf[1]]);
-
                 Ok(altitude)
             }
-            Err(_) => Err("Error reading sensor altitude"),
+            Err(e) => Err(e),
         }
     }
 
@@ -287,35 +285,41 @@ impl<'d> SCD41<'d> {
             .await
         {
             Ok(()) => {
-                if self.crc8(&buf[0..2]) != buf[2] {
-                    return Err("CRC mismatch in ambient pressure data");
-                }
-
                 let raw_pressure = u16::from_be_bytes([buf[0], buf[1]]);
-
-                // Convert to Pa: ambient P [Pa] = word[0] * 100
                 let pressure_pa = u32::from(raw_pressure) * 100;
-
                 Ok(pressure_pa)
             }
-            Err(_) => Err("Error reading ambient pressure"),
+            Err(e) => Err(e),
         }
     }
 
-    pub async fn set_temperature_offset(&mut self, offset: f32) -> Result<(), &'static str> {
-        if offset < 0.0 || offset > 20.0 {
-            return Err("Temperature offset must be between 0 °C and 20 °C");
+    pub async fn set_temperature_offset(
+        &mut self,
+        current_temp: f32,
+        reference_temp: f32,
+    ) -> Result<(), &'static str> {
+        let previous_offset = match self.get_temp_offset().await {
+            Ok(offset) => offset,
+            Err(e) => return Err(e),
+        };
+
+        //given eqn in the datasheet
+        let actual_offset = current_temp - reference_temp + previous_offset;
+
+        // Check if the calculated offset is within the recommended range, this is not a hard limit though
+        if actual_offset < 0.0 || actual_offset > 20.0 {
+            return Err("Calculated temperature offset must be between 0 °C and 20 °C");
         }
 
-        // Convert the offset to the raw value
         // word[0] = Toffset[°C] * (2^16 - 1) / 175
-        let raw_offset = ((offset * 65535.0) / 175.0) as u16;
+        let raw_offset = ((actual_offset * 65535.0) / 175.0) as u16;
         let offset_bytes = raw_offset.to_be_bytes();
 
         self.write_command(&CMD_SET_TEMPERATURE_OFFSET, &offset_bytes)
             .await
     }
 
+    //this value must be in meters
     pub async fn set_sensor_altitude(&mut self, altitude: u16) -> Result<(), &'static str> {
         if altitude > 3000 {
             return Err("Altitude must be between 0 and 3000 meters");
@@ -329,7 +333,7 @@ impl<'d> SCD41<'d> {
 
     pub async fn set_ambient_pressure(&mut self, pressure: u32) -> Result<(), &'static str> {
         if pressure < 70_000 || pressure > 120_000 {
-            return Err("Pressure must be between 70_000 and 120_000 Pa");
+            return Err("Pressure must be between 70,000 and 120,000 Pa");
         }
 
         let pressure_raw = (pressure / 100) as u16; // Convert Pa to 100 Pa units
@@ -338,4 +342,29 @@ impl<'d> SCD41<'d> {
         self.write_command(&CMD_SET_AMBIENT_PRESSURE, &pressure_bytes)
             .await
     }
+
+    //reserved for later use in case we decide to use perform_forced_recalibration
+    // async fn send_command_and_fetch_result(
+    //     &mut self,
+    //     address: &[u8],
+    //     data: &[u8],
+    //     result: &mut [u8],
+    // ) -> Result<(), &'static str> {
+    //     // Send command using the existing write_command function
+    //     self.write_command(address, data).await?;
+
+    //     self.i2c
+    //         .read(self.i2c_address, result)
+    //         .await
+    //         .map_err(|_| "Error fetching result")?;
+
+    //     let result_data_len = result.len() - 1;
+    //     let received_crc = result[result_data_len];
+    //     let calculated_crc = self.crc8(&result[..result_data_len]);
+    //     if received_crc != calculated_crc {
+    //         return Err("CRC mismatch in result");
+    //     }
+
+    //     Ok(())
+    // }
 }

--- a/src/drivers/scd41.rs
+++ b/src/drivers/scd41.rs
@@ -1,7 +1,7 @@
 use defmt::{error, info};
 use embassy_stm32::i2c::I2c;
 use embassy_stm32::mode::Async;
-use embassy_time::Timer;
+use embassy_time::{Duration, Timer};
 
 // I2C Address
 const SCD41_I2C_ADDRESS: u8 = 0x62;
@@ -34,7 +34,7 @@ const CMD_GET_DATA_READY_STATUS: [u8; 2] = [0xE4, 0xB8];
 
 // Advanced features
 // const CMD_PERSIST_SETTINGS: [u8; 2] = [0x36, 0x15];
-// const CMD_GET_SERIAL_NUMBER: [u8; 2] = [0x36, 0x82];
+const CMD_GET_SERIAL_NUMBER: [u8; 2] = [0x36, 0x82];
 const CMD_PERFORM_SELF_TEST: [u8; 2] = [0x36, 0x39];
 // const CMD_PERFORM_FACTORY_RESET: [u8; 2] = [0x36, 0x32];
 // const CMD_REINIT: [u8; 2] = [0x36, 0x46];
@@ -51,38 +51,35 @@ const CMD_PERFORM_SELF_TEST: [u8; 2] = [0x36, 0x39];
 // const CMD_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x23, 0x4B];
 
 // Execution times (in milliseconds)
-const INITIAL_MEASURE_DELAY: u32 = 500;
-const STOP_MEASURE_DELAY: u32 = 500;
-const PERFORM_SELF_TEST_DELAY: u32 = 10_000;
-
-// const EXECUTION_TIME_READ_MEASUREMENT: u32 = 1;
-// const EXECUTION_TIME_STOP_PERIODIC_MEASUREMENT: u32 = 500;
-// const EXECUTION_TIME_SET_TEMPERATURE_OFFSET: u32 = 1;
-// const EXECUTION_TIME_GET_TEMPERATURE_OFFSET: u32 = 1;
-// const EXECUTION_TIME_SET_SENSOR_ALTITUDE: u32 = 1;
-// const EXECUTION_TIME_GET_SENSOR_ALTITUDE: u32 = 1;
-// const EXECUTION_TIME_SET_AMBIENT_PRESSURE: u32 = 1;
-// const EXECUTION_TIME_GET_AMBIENT_PRESSURE: u32 = 1;
-// const EXECUTION_TIME_PERFORM_FORCED_RECALIBRATION: u32 = 400;
-// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
-// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
-// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
-// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
-// const EXECUTION_TIME_GET_DATA_READY_STATUS: u32 = 1;
-// const EXECUTION_TIME_PERSIST_SETTINGS: u32 = 800;
-// const EXECUTION_TIME_GET_SERIAL_NUMBER: u32 = 1;
-// const EXECUTION_TIME_PERFORM_SELF_TEST: u32 = 10000;
-// const EXECUTION_TIME_PERFORM_FACTORY_RESET: u32 = 1200;
-// const EXECUTION_TIME_REINIT: u32 = 30;
-// const EXECUTION_TIME_GET_SENSOR_VARIANT: u32 = 1;
-// const EXECUTION_TIME_MEASURE_SINGLE_SHOT: u32 = 5000;
-// const EXECUTION_TIME_MEASURE_SINGLE_SHOT_RHT_ONLY: u32 = 50;
-// const EXECUTION_TIME_POWER_DOWN: u32 = 1;
-// const EXECUTION_TIME_WAKE_UP: u32 = 30;
-// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
-// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
-// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
-// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
+const INITIAL_MEASURE_DELAY: u64 = 500;
+const STOP_MEASURE_DELAY: u64 = 500;
+const PERFORM_SELF_TEST_DELAY: u64 = 10_000;
+const EXECUTION_TIME_READ_MEASUREMENT: u64 = 1;
+const EXECUTION_TIME_SET_TEMPERATURE_OFFSET: u64 = 1;
+const EXECUTION_TIME_GET_TEMPERATURE_OFFSET: u64 = 1;
+const EXECUTION_TIME_SET_SENSOR_ALTITUDE: u64 = 1;
+const EXECUTION_TIME_GET_SENSOR_ALTITUDE: u64 = 1;
+const EXECUTION_TIME_SET_AMBIENT_PRESSURE: u64 = 1;
+const EXECUTION_TIME_GET_AMBIENT_PRESSURE: u64 = 1;
+// const EXECUTION_TIME_PERFORM_FORCED_RECALIBRATION: u64 = 400;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u64 = 1;
+// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u64 = 1;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: u64 = 1;
+// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: u64 = 1;
+const EXECUTION_TIME_GET_DATA_READY_STATUS: u64 = 1;
+// const EXECUTION_TIME_PERSIST_SETTINGS: u64 = 800;
+const EXECUTION_TIME_GET_SERIAL_NUMBER: u64 = 1;
+// const EXECUTION_TIME_PERFORM_SELF_TEST: u64 = 10000;
+// const EXECUTION_TIME_PERFORM_FACTORY_RESET: u64 = 1200;
+// const EXECUTION_TIME_REINIT: u64 = 30;
+// const EXECUTION_TIME_GET_SENSOR_VARIANT: u64 = 1;
+// const EXECUTION_TIME_MEASURE_SINGLE_SHOT: u64 = 5000;
+// const EXECUTION_TIME_MEASURE_SINGLE_SHOT_RHT_ONLY: u64 = 50;
+// const EXECUTION_TIME_POWER_DOWN: u64 = 1;
+// const EXECUTION_TIME_WAKE_UP: u64 = 30;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u64 = 1;
+// const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u64 = 1;
+// const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u64 = 1;
 
 //TODO make sure you stop measurement before any init commands
 pub struct SCD41<'d> {
@@ -99,31 +96,45 @@ impl<'d> SCD41<'d> {
     }
 
     pub async fn init(&mut self) -> Result<(), &'static str> {
+        if let Err(e) = self.stop_periodic_measurement().await {
+            error!("Failed to stop periodic measurement: {}", e);
+            return Err("Failed to stop periodic measurement");
+        }
+        info!("CMD_STOP_PERIODIC_MEASUREMENT successfully sent");
+
         match self.perform_self_test().await {
             Ok(true) => {
                 info!("SCD41 self-test passed");
-                Ok(())
             }
             Ok(false) => {
                 error!("Sensor malfunction detected -- this could be either physical or temporary");
-                Err("Sensor malfunction detected")
+                return Err("Sensor malfunction detected");
             }
             Err(e) => {
                 error!("Error while trying to perform self test: {}", e);
-                Err(e)
+                return Err("Failed to perform self-test");
             }
         }
+
+        if let Err(e) = self.start_periodic_measurement().await {
+            error!("Failed to start periodic measurement: {}", e);
+            return Err("Failed to start periodic measurement");
+        }
+        info!("CMD_START_PERIODIC_MEASUREMENT successfully sent");
+
         // [TODO] Set offsets here!!
+
+        Ok(())
     }
 
     //command words are not followed by CRC!
-    pub fn crc8(&mut self, data: &[u8]) -> u8 {
-        let mut crc: u8 = 0xFF; // Initialization value
+    pub fn crc8(&self, data: &[u8]) -> u8 {
+        let mut crc: u8 = 0xFF; // Initialization value (CRC8_INIT)
         for &byte in data {
             crc ^= byte;
             for _ in 0..8 {
                 if crc & 0x80 != 0 {
-                    crc = (crc << 1) ^ 0x31; // 0x31 is the polynomial
+                    crc = (crc << 1) ^ 0x31; // 0x31 is the polynomial (CRC8_POLYNOMIAL)
                 } else {
                     crc <<= 1;
                 }
@@ -132,6 +143,7 @@ impl<'d> SCD41<'d> {
         crc // No final XOR needed as it's 0x00
     }
 
+    //verified, works
     async fn send_command(&mut self, address: &[u8]) -> Result<(), &'static str> {
         self.i2c
             .write(self.i2c_address, address)
@@ -157,24 +169,38 @@ impl<'d> SCD41<'d> {
             .map_err(|_| "Error writing command")
     }
 
-    //make sure SR here is same as ST according to the transaction contract
-    //i.e make sure that both write_read and write and then read works here [TODO]
-    async fn read_sequence(&mut self, address: &[u8], buf: &mut [u8]) -> Result<(), &'static str> {
+    pub async fn read_sequence(
+        &mut self,
+        address: &[u8],
+        buf: &mut [u8],
+        millis: u64,
+    ) -> Result<(), &'static str> {
         self.i2c
-            .write_read(self.i2c_address, address, buf)
+            .write(self.i2c_address, address)
+            .await
+            .map_err(|_| "Error writing address")?;
+
+        Timer::after_millis(millis).await;
+
+        self.i2c
+            .read(self.i2c_address, buf)
             .await
             .map_err(|_| "Error reading sequence")?;
 
-        for chunk in buf.chunks(3) {
-            if chunk.len() == 3 {
-                let data = &chunk[0..2];
-                let received_crc = chunk[2];
+        let mut i = 0;
+        while i < buf.len() {
+            let remaining = buf.len() - i;
+            if remaining >= 3 {
+                let data = &buf[i..i + 2];
+                let received_crc = buf[i + 2];
                 let calculated_crc = self.crc8(data);
                 if calculated_crc != received_crc {
+                    error!("{:#x}", buf);
                     return Err("CRC mismatch in read data");
                 }
+                i += 3;
             } else {
-                return Err("The chunck was not divisible by 3");
+                break;
             }
         }
 
@@ -184,10 +210,10 @@ impl<'d> SCD41<'d> {
     pub async fn perform_self_test(&mut self) -> Result<bool, &'static str> {
         let mut buf = [0u8; 3];
 
-        self.send_command(&CMD_PERFORM_SELF_TEST).await?;
-        Timer::after_millis(PERFORM_SELF_TEST_DELAY.into()).await;
-
-        match self.read_sequence(&CMD_PERFORM_SELF_TEST, &mut buf).await {
+        match self
+            .read_sequence(&CMD_PERFORM_SELF_TEST, &mut buf, PERFORM_SELF_TEST_DELAY)
+            .await
+        {
             Ok(()) => {
                 let result = u16::from_be_bytes([buf[0], buf[1]]);
                 if result == 0 {
@@ -200,6 +226,7 @@ impl<'d> SCD41<'d> {
         }
     }
 
+    //verified works
     pub async fn start_periodic_measurement(&mut self) -> Result<(), &'static str> {
         self.send_command(&CMD_START_PERIODIC_MEASUREMENT)
             .await
@@ -211,10 +238,15 @@ impl<'d> SCD41<'d> {
     pub async fn get_data_ready_status(&mut self) -> Result<bool, &'static str> {
         let mut buf = [0u8; 3];
         match self
-            .read_sequence(&CMD_GET_DATA_READY_STATUS, &mut buf)
+            .read_sequence(
+                &CMD_GET_DATA_READY_STATUS,
+                &mut buf,
+                EXECUTION_TIME_GET_DATA_READY_STATUS,
+            )
             .await
         {
             Ok(()) => {
+                info!("{:#x}", buf);
                 if ((buf[0] & 0x07) == 0) && (buf[1] == 0) {
                     Ok(false)
                 } else {
@@ -225,10 +257,27 @@ impl<'d> SCD41<'d> {
         }
     }
 
+    //[TODO]: Debug this little bitch
     pub async fn read_measurement(&mut self) -> Result<(u16, f32, f32), &'static str> {
         let mut buf = [0u8; 9];
         if let Ok(true) = self.get_data_ready_status().await {
-            match self.read_sequence(&CMD_READ_MEASUREMENT, &mut buf).await {
+            info!("The data from the sensor is ready and can be read");
+            match self
+                .i2c
+                .write(self.i2c_address, &CMD_READ_MEASUREMENT)
+                .await
+            {
+                Ok(()) => {
+                    info!("written success")
+                }
+                Err(e) => {
+                    error!("can't write!")
+                }
+            };
+
+            Timer::after_millis(1).await;
+
+            match self.i2c.read(self.i2c_address, &mut buf).await {
                 Ok(()) => {
                     let co2 = u16::from_be_bytes([buf[0], buf[1]]);
                     let temperature =
@@ -237,13 +286,25 @@ impl<'d> SCD41<'d> {
 
                     Ok((co2, temperature, humidity))
                 }
-                Err(e) => Err(e),
+                Err(e) => Err("can't read"),
             }
+            // match self.read_sequence(&CMD_READ_MEASUREMENT, &mut buf).await {
+            //     Ok(()) => {
+            //         let co2 = u16::from_be_bytes([buf[0], buf[1]]);
+            //         let temperature =
+            //             -45.0 + 175.0 * (u16::from_be_bytes([buf[3], buf[4]]) as f32 / 65535.0);
+            //         let humidity = 100.0 * (u16::from_be_bytes([buf[6], buf[7]]) as f32 / 65535.0);
+
+            //         Ok((co2, temperature, humidity))
+            //     }
+            //     Err(e) => Err(e),
+            // }
         } else {
             Err("Sensor not ready yet. Try again in a few seconds")
         }
     }
 
+    //verified, works
     pub async fn stop_periodic_measurement(&mut self) -> Result<(), &'static str> {
         self.send_command(&CMD_STOP_PERIODIC_MEASUREMENT)
             .await
@@ -252,10 +313,15 @@ impl<'d> SCD41<'d> {
         Ok(())
     }
 
+    //[TODO] make sure all the get and set commands make sure that the i2c is not in the periodic mode otherwise they will fail with a NACK
     pub async fn get_temp_offset(&mut self) -> Result<f32, &'static str> {
         let mut buf = [0u8; 3];
         match self
-            .read_sequence(&CMD_GET_TEMPERATURE_OFFSET, &mut buf)
+            .read_sequence(
+                &CMD_GET_TEMPERATURE_OFFSET,
+                &mut buf,
+                EXECUTION_TIME_GET_TEMPERATURE_OFFSET,
+            )
             .await
         {
             Ok(()) => {
@@ -269,8 +335,16 @@ impl<'d> SCD41<'d> {
 
     pub async fn get_sensor_altitude(&mut self) -> Result<u16, &'static str> {
         let mut buf = [0u8; 3];
-        match self.read_sequence(&CMD_GET_SENSOR_ALTITUDE, &mut buf).await {
+        match self
+            .read_sequence(
+                &CMD_GET_SENSOR_ALTITUDE,
+                &mut buf,
+                EXECUTION_TIME_GET_SENSOR_ALTITUDE,
+            )
+            .await
+        {
             Ok(()) => {
+                info!("{:#x}", buf);
                 let altitude = u16::from_be_bytes([buf[0], buf[1]]);
                 Ok(altitude)
             }
@@ -281,7 +355,11 @@ impl<'d> SCD41<'d> {
     pub async fn get_ambient_pressure(&mut self) -> Result<u32, &'static str> {
         let mut buf = [0u8; 3];
         match self
-            .read_sequence(&CMD_GET_AMBIENT_PRESSURE, &mut buf)
+            .read_sequence(
+                &CMD_GET_AMBIENT_PRESSURE,
+                &mut buf,
+                EXECUTION_TIME_GET_AMBIENT_PRESSURE,
+            )
             .await
         {
             Ok(()) => {
@@ -341,6 +419,23 @@ impl<'d> SCD41<'d> {
 
         self.write_command(&CMD_SET_AMBIENT_PRESSURE, &pressure_bytes)
             .await
+    }
+
+    //the answer should be: [0x7d, 0x6b, 0xab, 0x7b, 0x7, 0x37, 0x3b, 0x12, 0x8]
+    pub async fn get_serial_number(&mut self) -> Result<[u8; 9], &'static str> {
+        let mut buf = [0u8; 9]; // 3 words, each followed by CRC (3 * (2 + 1) = 9)
+
+        match self
+            .read_sequence(
+                &CMD_GET_SERIAL_NUMBER,
+                &mut buf,
+                EXECUTION_TIME_GET_SERIAL_NUMBER,
+            )
+            .await
+        {
+            Ok(()) => Ok(buf),
+            Err(e) => Err(e),
+        }
     }
 
     //reserved for later use in case we decide to use perform_forced_recalibration

--- a/src/drivers/scd41.rs
+++ b/src/drivers/scd41.rs
@@ -1,0 +1,341 @@
+use embassy_stm32::i2c::I2c;
+use embassy_stm32::mode::Async;
+use embassy_time::Timer;
+
+// I2C Address
+const SCD41_I2C_ADDRESS: u8 = 0x62;
+
+const POWERUP_TIME: u32 = 40; // millisec
+
+// Basic commands
+const CMD_START_PERIODIC_MEASUREMENT: [u8; 2] = [0x21, 0xB1];
+const CMD_READ_MEASUREMENT: [u8; 2] = [0xEC, 0x05];
+const CMD_STOP_PERIODIC_MEASUREMENT: [u8; 2] = [0x3F, 0x86];
+
+// On-chip output signal compensation
+const CMD_SET_TEMPERATURE_OFFSET: [u8; 2] = [0x24, 0x1D];
+const CMD_GET_TEMPERATURE_OFFSET: [u8; 2] = [0x23, 0x18];
+const CMD_SET_SENSOR_ALTITUDE: [u8; 2] = [0x24, 0x27];
+const CMD_GET_SENSOR_ALTITUDE: [u8; 2] = [0x23, 0x22];
+const CMD_SET_AMBIENT_PRESSURE: [u8; 2] = [0xE0, 0x00];
+const CMD_GET_AMBIENT_PRESSURE: [u8; 2] = [0xE0, 0x00];
+
+// Field calibration
+const CMD_PERFORM_FORCED_RECALIBRATION: [u8; 2] = [0x36, 0x2F];
+const CMD_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: [u8; 2] = [0x24, 0x16];
+const CMD_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: [u8; 2] = [0x23, 0x13];
+const CMD_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: [u8; 2] = [0x24, 0x3A];
+const CMD_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: [u8; 2] = [0x23, 0x3F];
+
+// Low power periodic measurement mode
+const CMD_START_LOW_POWER_PERIODIC_MEASUREMENT: [u8; 2] = [0x21, 0xAC];
+const CMD_GET_DATA_READY_STATUS: [u8; 2] = [0xE4, 0xB8];
+
+// Advanced features
+const CMD_PERSIST_SETTINGS: [u8; 2] = [0x36, 0x15];
+const CMD_GET_SERIAL_NUMBER: [u8; 2] = [0x36, 0x82];
+const CMD_PERFORM_SELF_TEST: [u8; 2] = [0x36, 0x39];
+const CMD_PERFORM_FACTORY_RESET: [u8; 2] = [0x36, 0x32];
+const CMD_REINIT: [u8; 2] = [0x36, 0x46];
+const CMD_GET_SENSOR_VARIANT: [u8; 2] = [0x20, 0x2F];
+
+// Single shot measurement mode
+const CMD_MEASURE_SINGLE_SHOT: [u8; 2] = [0x21, 0x9D];
+const CMD_MEASURE_SINGLE_SHOT_RHT_ONLY: [u8; 2] = [0x21, 0x96];
+const CMD_POWER_DOWN: [u8; 2] = [0x36, 0xE0];
+const CMD_WAKE_UP: [u8; 2] = [0x36, 0xF6];
+const CMD_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: [u8; 2] = [0x24, 0x45];
+const CMD_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: [u8; 2] = [0x23, 0x40];
+const CMD_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x24, 0x4E];
+const CMD_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: [u8; 2] = [0x23, 0x4B];
+
+// Execution times (in milliseconds)
+const INITIAL_MEASURE_DELAY: u32 = 500;
+const EXECUTION_TIME_READ_MEASUREMENT: u32 = 1;
+const EXECUTION_TIME_STOP_PERIODIC_MEASUREMENT: u32 = 500;
+const EXECUTION_TIME_SET_TEMPERATURE_OFFSET: u32 = 1;
+const EXECUTION_TIME_GET_TEMPERATURE_OFFSET: u32 = 1;
+const EXECUTION_TIME_SET_SENSOR_ALTITUDE: u32 = 1;
+const EXECUTION_TIME_GET_SENSOR_ALTITUDE: u32 = 1;
+const EXECUTION_TIME_SET_AMBIENT_PRESSURE: u32 = 1;
+const EXECUTION_TIME_GET_AMBIENT_PRESSURE: u32 = 1;
+const EXECUTION_TIME_PERFORM_FORCED_RECALIBRATION: u32 = 400;
+const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
+const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_ENABLED: u32 = 1;
+const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
+const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_TARGET: u32 = 1;
+const EXECUTION_TIME_GET_DATA_READY_STATUS: u32 = 1;
+const EXECUTION_TIME_PERSIST_SETTINGS: u32 = 800;
+const EXECUTION_TIME_GET_SERIAL_NUMBER: u32 = 1;
+const EXECUTION_TIME_PERFORM_SELF_TEST: u32 = 10000;
+const EXECUTION_TIME_PERFORM_FACTORY_RESET: u32 = 1200;
+const EXECUTION_TIME_REINIT: u32 = 30;
+const EXECUTION_TIME_GET_SENSOR_VARIANT: u32 = 1;
+const EXECUTION_TIME_MEASURE_SINGLE_SHOT: u32 = 5000;
+const EXECUTION_TIME_MEASURE_SINGLE_SHOT_RHT_ONLY: u32 = 50;
+const EXECUTION_TIME_POWER_DOWN: u32 = 1;
+const EXECUTION_TIME_WAKE_UP: u32 = 30;
+const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
+const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_INITIAL_PERIOD: u32 = 1;
+const EXECUTION_TIME_SET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
+const EXECUTION_TIME_GET_AUTOMATIC_SELF_CALIBRATION_STANDARD_PERIOD: u32 = 1;
+
+pub struct SCD41<'d> {
+    i2c: I2c<'d, Async>,
+    i2c_address: u8,
+}
+
+impl<'d> SCD41<'d> {
+    pub fn new(i2c: I2c<'d, Async>) -> Self {
+        SCD41 {
+            i2c: i2c,
+            i2c_address: SCD41_I2C_ADDRESS,
+        }
+    }
+
+    //command words are not followed by CRC!!
+    //get this CRC checked once
+    fn crc8(&mut self, data: &[u8]) -> u8 {
+        let mut crc: u8 = 0xFF; // Initialization value
+        for &byte in data {
+            crc ^= byte;
+            for _ in 0..8 {
+                if crc & 0x80 != 0 {
+                    crc = (crc << 1) ^ 0x31; // 0x31 is the polynomial
+                } else {
+                    crc <<= 1;
+                }
+            }
+        }
+        crc // No final XOR needed as it's 0x00
+    }
+
+    async fn write_command(&mut self, address: &[u8], data: &[u8]) -> Result<(), &'static str> {
+        const MAX_LENGTH: usize = 32;
+        let mut combined = [0u8; MAX_LENGTH];
+
+        if address.len() + data.len() + 1 > MAX_LENGTH {
+            return Err("Command too long");
+        }
+
+        let crc = self.crc8(data);
+
+        let mut index = 0;
+
+        for &byte in address {
+            combined[index] = byte;
+            index += 1;
+        }
+
+        for &byte in data {
+            combined[index] = byte;
+            index += 1;
+        }
+
+        combined[index] = crc;
+        index += 1;
+
+        self.i2c
+            .write(self.i2c_address, &combined[..index])
+            .await
+            .map_err(|_| "Error writing command")
+    }
+
+    //make sure SR here is same as ST according to the transaction contract
+    //i.e make sure it is write_read and not write and then read
+    async fn read_sequence(&mut self, address: &[u8], buf: &mut [u8]) -> Result<(), &'static str> {
+        self.i2c
+            .write_read(self.i2c_address, address, buf)
+            .await
+            .map_err(|_| "Error reading sequence")
+    }
+
+    async fn send_command(&mut self, address: &[u8]) -> Result<(), &'static str> {
+        self.i2c
+            .write(self.i2c_address, address)
+            .await
+            .map_err(|_| "Error writing command")
+    }
+
+    async fn send_command_and_fetch_result(
+        &mut self,
+        address: &[u8],
+        data: &[u8],
+        result: &mut [u8],
+    ) -> Result<(), &'static str> {
+        // Send command using the existing write_command function
+        self.write_command(address, data).await?;
+
+        self.i2c
+            .read(self.i2c_address, result)
+            .await
+            .map_err(|_| "Error fetching result")?;
+
+        let result_data_len = result.len() - 1;
+        let received_crc = result[result_data_len];
+        let calculated_crc = self.crc8(&result[..result_data_len]);
+        if received_crc != calculated_crc {
+            return Err("CRC mismatch in result");
+        }
+
+        Ok(())
+    }
+
+    pub async fn start_periodic_measurement(&mut self) -> Result<(), &'static str> {
+        self.send_command(&CMD_START_PERIODIC_MEASUREMENT)
+            .await
+            .map_err(|_| "Failed to start measurement")?;
+        Timer::after_millis(INITIAL_MEASURE_DELAY.into()).await;
+        Ok(())
+    }
+
+    pub async fn get_data_ready_status(&mut self) -> Result<bool, &'static str> {
+        let mut buf = [0u8; 3];
+        match self
+            .read_sequence(&CMD_GET_DATA_READY_STATUS, &mut buf)
+            .await
+        {
+            Ok(()) => {
+                if self.crc8(&buf[0..=1]) == buf[2] {
+                    if (buf[0] & 0x07 == 0) && (buf[1] == 0) {
+                        Ok(false)
+                    } else {
+                        Ok(true)
+                    }
+                } else {
+                    Err("the CRC has failed")
+                }
+            }
+            Err(_) => Err("Failed to read data ready status: {}"),
+        }
+    }
+
+    pub async fn read_measurement(&mut self) -> Result<(u16, f32, f32), &'static str> {
+        let mut buf = [0u8; 9];
+        if let Ok(true) = self.get_data_ready_status().await {
+            match self.read_sequence(&CMD_READ_MEASUREMENT, &mut buf).await {
+                Ok(()) => {
+                    if self.crc8(&buf[0..2]) != buf[2]
+                        || self.crc8(&buf[3..5]) != buf[5]
+                        || self.crc8(&buf[6..8]) != buf[8]
+                    {
+                        return Err("CRC mismatch in measurement data");
+                    }
+
+                    let co2 = u16::from_be_bytes([buf[0], buf[1]]);
+                    let temperature =
+                        -45.0 + 175.0 * u16::from_be_bytes([buf[3], buf[4]]) as f32 / 65535.0;
+                    let humidity = 100.0 * u16::from_be_bytes([buf[6], buf[7]]) as f32 / 65535.0;
+
+                    Ok((co2, temperature, humidity))
+                }
+                Err(_) => Err("Failed to read measurement data"),
+            }
+        } else {
+            Err("Sensor not ready yet. Try again in a few seconds")
+        }
+    }
+
+    pub async fn stop_periodic_measurement(&mut self) -> Result<(), &'static str> {
+        self.send_command(&CMD_STOP_PERIODIC_MEASUREMENT)
+            .await
+            .map_err(|_| "Failed to stop measurement")?;
+        Timer::after_millis(INITIAL_MEASURE_DELAY.into()).await;
+        Ok(())
+    }
+
+    pub async fn get_temp_offset(&mut self) -> Result<f32, &'static str> {
+        let mut buf = [0u8; 3];
+        match self
+            .read_sequence(&CMD_GET_TEMPERATURE_OFFSET, &mut buf)
+            .await
+        {
+            Ok(()) => {
+                if self.crc8(&buf[0..2]) != buf[2] {
+                    return Err("CRC mismatch in temperature offset data");
+                }
+
+                let raw_offset = u16::from_be_bytes([buf[0], buf[1]]);
+                let temp_offset = raw_offset as f32 * 175.0 / 65535.0;
+
+                Ok(temp_offset)
+            }
+            Err(_) => Err("Error reading temperature offset"),
+        }
+    }
+
+    pub async fn get_sensor_altitude(&mut self) -> Result<u16, &'static str> {
+        let mut buf = [0u8; 3];
+        match self.read_sequence(&CMD_GET_SENSOR_ALTITUDE, &mut buf).await {
+            Ok(()) => {
+                if self.crc8(&buf[0..2]) != buf[2] {
+                    return Err("CRC mismatch in sensor altitude data");
+                }
+
+                let altitude = u16::from_be_bytes([buf[0], buf[1]]);
+
+                Ok(altitude)
+            }
+            Err(_) => Err("Error reading sensor altitude"),
+        }
+    }
+
+    pub async fn get_ambient_pressure(&mut self) -> Result<u32, &'static str> {
+        let mut buf = [0u8; 3];
+        match self
+            .read_sequence(&CMD_GET_AMBIENT_PRESSURE, &mut buf)
+            .await
+        {
+            Ok(()) => {
+                if self.crc8(&buf[0..2]) != buf[2] {
+                    return Err("CRC mismatch in ambient pressure data");
+                }
+
+                let raw_pressure = u16::from_be_bytes([buf[0], buf[1]]);
+
+                // Convert to Pa: ambient P [Pa] = word[0] * 100
+                let pressure_pa = u32::from(raw_pressure) * 100;
+
+                Ok(pressure_pa)
+            }
+            Err(_) => Err("Error reading ambient pressure"),
+        }
+    }
+
+    pub async fn set_temperature_offset(&mut self, offset: f32) -> Result<(), &'static str> {
+        if offset < 0.0 || offset > 20.0 {
+            return Err("Temperature offset must be between 0 °C and 20 °C");
+        }
+
+        // Convert the offset to the raw value
+        // word[0] = Toffset[°C] * (2^16 - 1) / 175
+        let raw_offset = ((offset * 65535.0) / 175.0) as u16;
+        let offset_bytes = raw_offset.to_be_bytes();
+
+        self.write_command(&CMD_SET_TEMPERATURE_OFFSET, &offset_bytes)
+            .await
+    }
+
+    pub async fn set_sensor_altitude(&mut self, altitude: u16) -> Result<(), &'static str> {
+        if altitude > 3000 {
+            return Err("Altitude must be between 0 and 3000 meters");
+        }
+
+        let altitude_bytes = altitude.to_be_bytes();
+
+        self.write_command(&CMD_SET_SENSOR_ALTITUDE, &altitude_bytes)
+            .await
+    }
+
+    pub async fn set_ambient_pressure(&mut self, pressure: u32) -> Result<(), &'static str> {
+        if pressure < 70_000 || pressure > 120_000 {
+            return Err("Pressure must be between 70_000 and 120_000 Pa");
+        }
+
+        let pressure_raw = (pressure / 100) as u16; // Convert Pa to 100 Pa units
+        let pressure_bytes = pressure_raw.to_be_bytes();
+
+        self.write_command(&CMD_SET_AMBIENT_PRESSURE, &pressure_bytes)
+            .await
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,12 +47,51 @@ async fn main(_spawner: Spawner) {
         }
     }
 
-    match scd41sensor.get_serial_number().await {
-        Ok(abc) => {
-            info!("we got: {:#x}", abc)
-        }
-        Err(e) => {
-            error!("error: {}", e)
-        }
-    }
+    // match scd41sensor.get_serial_number().await {
+    //     Ok(serial_no) => {
+    //         info!("serial_no: {}", serial_no);
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
+
+    // match scd41sensor.init().await {
+    //     Ok(()) => {
+    //         info!("Initialization successful");
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
+
+    // match scd41sensor.get_serial_number().await {
+    //     Ok(serial_no) => {
+    //         info!("serial_no: {}", serial_no);
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
+
+    // match scd41sensor.read_measurement().await {
+    //     Ok((a, b, c)) => {
+    //         info!(
+    //             "The data is ready: co2: {}, temp: {}, humidity: {}",
+    //             a, b, c
+    //         );
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
+
+    // match scd41sensor.get_serial_number().await {
+    //     Ok(abc) => {
+    //         info!("we got: {:#x}", abc)
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use embassy_stm32::time::Hertz;
 use embassy_time::{block_for, Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 mod drivers;
-use drivers::scd41::SCD41;
+use drivers::scd41::{SensorSettings, SCD41};
 
 bind_interrupts!(struct Irqs {
     I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
@@ -25,7 +25,7 @@ async fn main(_spawner: Spawner) {
     config.scl_pullup = true;
     config.sda_pullup = true;
 
-    let mut i2c = I2c::new(
+    let i2c = I2c::new(
         p.I2C1,
         p.PB6,
         p.PB7,
@@ -38,27 +38,54 @@ async fn main(_spawner: Spawner) {
 
     let mut scd41sensor = SCD41::new(i2c);
 
-    match scd41sensor.stop_periodic_measurement().await {
+    match scd41sensor.init(Some(SensorSettings::Default)).await {
         Ok(()) => {
-            info!("stop_periodic_measurement successful");
+            info!("Initialization successful");
         }
         Err(e) => {
             error!("error: {}", e)
         }
     }
 
-    // match scd41sensor.get_serial_number().await {
-    //     Ok(serial_no) => {
-    //         info!("serial_no: {}", serial_no);
+    // match scd41sensor.stop_periodic_measurement().await {
+    //     Ok(()) => {
+    //         info!("stop_periodic_measurement successful");
     //     }
     //     Err(e) => {
     //         error!("error: {}", e)
     //     }
     // }
 
-    // match scd41sensor.init().await {
+    // match scd41sensor.get_ambient_pressure().await {
+    //     Ok(num) => {
+    //         info!("sensor altitude: {}", num);
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
+
+    // match scd41sensor.set_ambient_pressure(101_300).await {
     //     Ok(()) => {
-    //         info!("Initialization successful");
+    //         info!("set done");
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
+
+    // match scd41sensor.get_ambient_pressure().await {
+    //     Ok(num) => {
+    //         info!("sensor altitude: {}", num);
+    //     }
+    //     Err(e) => {
+    //         error!("error: {}", e)
+    //     }
+    // }
+
+    // match scd41sensor.get_serial_number().await {
+    //     Ok(serial_no) => {
+    //         info!("serial_no: {}", serial_no);
     //     }
     //     Err(e) => {
     //         error!("error: {}", e)

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,94 +36,23 @@ async fn main(_spawner: Spawner) {
         config,
     );
 
-    // match i2c.write(0x62, &[0x21, 0xB1]).await {
-    //     Ok(()) => {
-    //         info!("works");
-    //     }
-    //     Err(e) => {
-    //         error!("error {}", e);
-    //     }
-    // }
-
     let mut scd41sensor = SCD41::new(i2c);
 
     match scd41sensor.stop_periodic_measurement().await {
         Ok(()) => {
-            info!("works!");
+            info!("stop_periodic_measurement successful");
         }
         Err(e) => {
             error!("error: {}", e)
         }
     }
 
-    Timer::after_millis(500).await;
-
-    match scd41sensor.init().await {
-        Ok(()) => {
-            info!("works!");
+    match scd41sensor.get_serial_number().await {
+        Ok(abc) => {
+            info!("we got: {:#x}", abc)
         }
         Err(e) => {
             error!("error: {}", e)
         }
     }
-
-    // match i2c.write(0x62, &[0x36, 0x39]).await {
-    //     Ok(()) => {
-    //         info!("Self-test command sent successfully")
-    //     }
-    //     Err(e) => error!("Error sending self-test command: {}", e),
-    // }
-
-    // // Wait for the specified execution time (10 seconds)
-    // Timer::after_millis(10_000).await;
-
-    // // Read the response (3 bytes)
-    // let mut buf = [0u8; 3];
-    // match i2c.read(0x62, &mut buf).await {
-    //     Ok(()) => {
-    //         info!(
-    //             "Self-test response read successfully: {:#04x} {:#04x} {:#04x}",
-    //             buf[0], buf[1], buf[2]
-    //         );
-
-    //         // Interpret the result
-    //         if buf[0] == 0x00 && buf[1] == 0x00 {
-    //             info!("Self-test passed: No malfunction detected");
-    //         } else {
-    //             error!("Self-test failed: Malfunction detected");
-    //         }
-    //     }
-    //     Err(e) => error!("Error reading self-test response: {}", e),
-    // }
-
-    // let mut scd_sensor = SCD41::new(i2c);
-
-    // match scd_sensor.init().await {
-    //     Ok(()) => {}
-    //     Err(e) => {
-    //         error!("{}", e)
-    //     }
-    // }
-
-    // match scd_sensor.start_periodic_measurement().await {
-    //     Ok(()) => {}
-    //     Err(e) => {
-    //         error!("{}", e)
-    //     }
-    // }
-}
-
-pub fn crc8(data: &[u8]) -> u8 {
-    let mut crc: u8 = 0xFF; // Initialization value
-    for &byte in data {
-        crc ^= byte;
-        for _ in 0..8 {
-            if crc & 0x80 != 0 {
-                crc = (crc << 1) ^ 0x31; // 0x31 is the polynomial
-            } else {
-                crc <<= 1;
-            }
-        }
-    }
-    crc // No final XOR needed as it's 0x00
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,87 +3,37 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
-use embassy_stm32::usart::{Config, DataBits, Parity, StopBits, Uart};
-use embassy_stm32::{bind_interrupts, peripherals, usart};
-use embassy_time::Timer;
+use embassy_stm32::i2c::{Config, I2c};
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
+
+use embassy_stm32::time::Hertz;
+use embassy_time::{block_for, Duration};
 use {defmt_rtt as _, panic_probe as _};
 mod drivers;
-use drivers::explorir_m_e_100::ExplorIrME100;
+use drivers::scd41::SCD41;
 
 bind_interrupts!(struct Irqs {
-    USART3 => usart::InterruptHandler<peripherals::USART3>;
+    I2C2_EV => i2c::EventInterruptHandler<peripherals::I2C2>;
+    I2C2_ER => i2c::ErrorInterruptHandler<peripherals::I2C2>;
 });
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     let p = embassy_stm32::init(Default::default());
-    info!("Hello World!");
-
     let mut config = Config::default();
-    config.baudrate = 9600;
-    config.parity = Parity::ParityNone;
-    config.stop_bits = StopBits::STOP1;
-    config.data_bits = DataBits::DataBits8;
+    config.scl_pullup = true;
+    config.sda_pullup = true;
 
-    let mut usart =
-        Uart::new(p.USART3, p.PD9, p.PD8, Irqs, p.DMA1_CH3, p.DMA1_CH1, config).unwrap();
+    let mut i2c = I2c::new(
+        p.I2C2,
+        p.PB10,
+        p.PB11,
+        Irqs,
+        p.DMA1_CH7,
+        p.DMA1_CH2,
+        Hertz(100_000),
+        config,
+    );
 
-    Timer::after_secs(2).await;
-
-    // let cmd = ([0x2E, 0x0D, 0x0A, 0x00]); //this is the command to read the serial no
-
-    // match usart.write(&cmd).await {
-    //     Ok(val) => {
-    //         info!("Command sent successfully: {}", val);
-    //     }
-    //     Err(_) => {
-    //         error!("Failed to send command");
-    //     }
-    // }
-
-    // let mut response = [0u8; 10];
-    // let mut index = 0;
-
-    // while index < response.len() {
-    //     match usart.read(&mut response[index..index + 1]).await {
-    //         Ok(_) => {
-    //             index += 1;
-    //         }
-    //         Err(_) => {
-    //             error!("Error while reading");
-    //             break;
-    //         }
-    //     }
-    // }
-
-    // info!(
-    //     "Raw response bytes: {:?}",
-    //     core::str::from_utf8(&response[..index]).unwrap_or("<invalid UTF-8>")
-    // );
-
-    let mut co2_sensor = ExplorIrME100::new(usart);
-    match co2_sensor.get_filtered_co2().await {
-        Ok(co2_level) => {
-            info!("CO2 level: {} ppm", co2_level);
-        }
-        Err(error_msg) => {
-            info!("Failed to get CO2 reading: {}", error_msg);
-        }
-    }
-
-    match co2_sensor.read_serial_no().await {
-        Ok(msg) => {
-            info!("{}", msg);
-        }
-        Err(error_msg) => {
-            info!("Failed: {}", error_msg);
-        }
-    }
-
-    Timer::after_secs(2).await;
-
-    match co2_sensor.get_pressure_and_concentration().await {
-        Ok(val) => info!("the value is now {}", val),
-        Err(e) => info!("{}", e),
-    }
+    let mut co2_sensor = SCD41::new(i2c);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,19 @@
 
 use defmt::*;
 use embassy_executor::Spawner;
+use embassy_stm32::gpio::Output;
 use embassy_stm32::i2c::{Config, I2c};
 use embassy_stm32::{bind_interrupts, i2c, peripherals};
 
 use embassy_stm32::time::Hertz;
-use embassy_time::{block_for, Duration};
+use embassy_time::{block_for, Duration, Timer};
 use {defmt_rtt as _, panic_probe as _};
 mod drivers;
 use drivers::scd41::SCD41;
 
 bind_interrupts!(struct Irqs {
-    I2C2_EV => i2c::EventInterruptHandler<peripherals::I2C2>;
-    I2C2_ER => i2c::ErrorInterruptHandler<peripherals::I2C2>;
+    I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+    I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
 });
 
 #[embassy_executor::main]
@@ -25,15 +26,104 @@ async fn main(_spawner: Spawner) {
     config.sda_pullup = true;
 
     let mut i2c = I2c::new(
-        p.I2C2,
-        p.PB10,
-        p.PB11,
+        p.I2C1,
+        p.PB6,
+        p.PB7,
         Irqs,
-        p.DMA1_CH7,
-        p.DMA1_CH2,
+        p.DMA1_CH6,
+        p.DMA1_CH0,
         Hertz(100_000),
         config,
     );
 
-    let mut co2_sensor = SCD41::new(i2c);
+    // match i2c.write(0x62, &[0x21, 0xB1]).await {
+    //     Ok(()) => {
+    //         info!("works");
+    //     }
+    //     Err(e) => {
+    //         error!("error {}", e);
+    //     }
+    // }
+
+    let mut scd41sensor = SCD41::new(i2c);
+
+    match scd41sensor.stop_periodic_measurement().await {
+        Ok(()) => {
+            info!("works!");
+        }
+        Err(e) => {
+            error!("error: {}", e)
+        }
+    }
+
+    Timer::after_millis(500).await;
+
+    match scd41sensor.init().await {
+        Ok(()) => {
+            info!("works!");
+        }
+        Err(e) => {
+            error!("error: {}", e)
+        }
+    }
+
+    // match i2c.write(0x62, &[0x36, 0x39]).await {
+    //     Ok(()) => {
+    //         info!("Self-test command sent successfully")
+    //     }
+    //     Err(e) => error!("Error sending self-test command: {}", e),
+    // }
+
+    // // Wait for the specified execution time (10 seconds)
+    // Timer::after_millis(10_000).await;
+
+    // // Read the response (3 bytes)
+    // let mut buf = [0u8; 3];
+    // match i2c.read(0x62, &mut buf).await {
+    //     Ok(()) => {
+    //         info!(
+    //             "Self-test response read successfully: {:#04x} {:#04x} {:#04x}",
+    //             buf[0], buf[1], buf[2]
+    //         );
+
+    //         // Interpret the result
+    //         if buf[0] == 0x00 && buf[1] == 0x00 {
+    //             info!("Self-test passed: No malfunction detected");
+    //         } else {
+    //             error!("Self-test failed: Malfunction detected");
+    //         }
+    //     }
+    //     Err(e) => error!("Error reading self-test response: {}", e),
+    // }
+
+    // let mut scd_sensor = SCD41::new(i2c);
+
+    // match scd_sensor.init().await {
+    //     Ok(()) => {}
+    //     Err(e) => {
+    //         error!("{}", e)
+    //     }
+    // }
+
+    // match scd_sensor.start_periodic_measurement().await {
+    //     Ok(()) => {}
+    //     Err(e) => {
+    //         error!("{}", e)
+    //     }
+    // }
+}
+
+pub fn crc8(data: &[u8]) -> u8 {
+    let mut crc: u8 = 0xFF; // Initialization value
+    for &byte in data {
+        crc ^= byte;
+        for _ in 0..8 {
+            if crc & 0x80 != 0 {
+                crc = (crc << 1) ^ 0x31; // 0x31 is the polynomial
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+    crc // No final XOR needed as it's 0x00
 }


### PR DESCRIPTION
- Create SCD41 driver structure with I2C communication
- Implement core sensor commands (start/stop measurement, read data)
- Add SensorSettings enum for custom and default configurations
- Develop initialization process with self-test and settings application
- Implement temperature offset, altitude, and ambient pressure settings
- Add methods for reading CO2, temperature, and humidity measurements
- Implement CRC8 calculation and validation for data integrity
- Add get_serial_number functionality for device identification
- Improve error handling and logging throughout the driver
- Ensure proper state management between idle and measurement modes
- Implement retry logic for data reading with configurable attempts
- Add constants for execution times and I2C command definitions
- Refactor code for better readability and maintainability
- Prepare driver for integration and comprehensive testing

Note:
- The sensor is not intended for CO2 measurements in the current design; the CO2 calibration interface is not implemented.
- Single shot measurement features are not implemented in this version.